### PR TITLE
Support Line Break (\n) style addresses

### DIFF
--- a/src/AddressStruct.php
+++ b/src/AddressStruct.php
@@ -16,7 +16,11 @@ class AddressStruct
     public $error_message;
 
     public $country;
+
+    /** @var string 2-char state code (abbreviation). E.g.: NY */
     public $state;
+
+    /** @var string Full name of the state, no abbreviation. E.g.: New York */
     public $state_text;
     public $city;
     public $addressLine1;
@@ -28,7 +32,7 @@ class AddressStruct
     public function __construct($addressArray)
     {
         if (!$addressArray || !is_array($addressArray)) {
-            return true;
+            return;
         }
         $this->country      = isset($addressArray['country']) ? $addressArray['country'] : self::US;
         $this->state        = isset($addressArray['state']) ? $addressArray['state'] : '';
@@ -38,8 +42,5 @@ class AddressStruct
         $this->zipcode      = isset($addressArray['zipcode']) ? $addressArray['zipcode'] : '';
         $this->name         = isset($addressArray['name']) ? $addressArray['name'] : '';
         $this->plus4        = isset($addressArray['plus4']) ? $addressArray['plus4'] : '';
-
-        return $this;
     }
-
 }

--- a/src/AddressStruct.php
+++ b/src/AddressStruct.php
@@ -8,13 +8,19 @@
 
 namespace CarpCai\AddressParser;
 
+use CarpCai\AddressParser\Data\UsaData;
+
 class AddressStruct
 {
-    const US = 'US';
+    const US = UsaData::COUNTRY_CODE;
 
+    /** @var int Error code, will be set if an error happened during parsing. */
     public $error_code;
+
+    /** @var string Error message, will be set if an error happened during parsing. */
     public $error_message;
 
+    /** @var string 2-char country code (abbreviation). E.g.: US */
     public $country;
 
     /** @var string 2-char state code (abbreviation). E.g.: NY */
@@ -34,7 +40,7 @@ class AddressStruct
         if (!$addressArray || !is_array($addressArray)) {
             return;
         }
-        $this->country      = isset($addressArray['country']) ? $addressArray['country'] : self::US;
+        $this->country      = isset($addressArray['country']) ? $addressArray['country'] : UsaData::COUNTRY_CODE;
         $this->state        = isset($addressArray['state']) ? $addressArray['state'] : '';
         $this->city         = isset($addressArray['city']) ? $addressArray['city'] : '';
         $this->addressLine1 = isset($addressArray['addressLine1']) ? $addressArray['addressLine1'] : '';

--- a/src/Countries/BaseCountryParser.php
+++ b/src/Countries/BaseCountryParser.php
@@ -13,7 +13,7 @@ class BaseCountryParser
     /**
      * CarpCai <2018/12/2 7:57 PM>
      */
-    protected function _setError(&$addressStruct, $error_message)
+    protected function _setError($addressStruct, $error_message)
     {
         $addressStruct->error_code = -1;
         $addressStruct->error_message = $error_message;

--- a/src/Countries/USParser.php
+++ b/src/Countries/USParser.php
@@ -9,23 +9,40 @@
 namespace CarpCai\AddressParser\Countries;
 
 use CarpCai\AddressParser\AddressStruct;
+use CarpCai\AddressParser\Data\UsaData;
 
 class USParser extends BaseCountryParser implements iParser
 {
     /**
      * CarpCai <2018/12/1 10:47 PM>
-     * @param $addressString
+     * @param string $addressString
      * @return AddressStruct
      */
     public function split($addressString)
     {
+        // Convert line breaks to commas
+        $addressString = str_replace(["\r\n", "\n", "\r"], ", ", $addressString);
+
+        $matches = [];
+
+        // Example input: John Doe, 555 Test Drive, Testville, CA 98773
         preg_match(
             "/([A-Za-z_ ]*)(.*),([A-Za-z_ ]*),([A-Za-z_ ]*)([0-9]*)(-([0-9]{4})){0,1}/",
             $addressString,
             $matches
         );
 
+        if (!$matches || count($matches) < 6) {
+            $address = new AddressStruct([]);
+            $address->error_code = -1;
+            $address->error_message = 'Failed to match regular expression.';
+            return $address;
+        }
+
         list($original, $name, $street, $city, $state, $zipcode) = $matches;
+
+        $street = ltrim($street, ", ");
+
         $address = new AddressStruct([
             'name'         => trim($name),
             'city'         => trim($city),

--- a/src/Countries/USParser.php
+++ b/src/Countries/USParser.php
@@ -35,7 +35,6 @@ class USParser extends BaseCountryParser implements iParser
         ]);
         
         if (isset($matches[7])) {
-            //var_dump($matches[7]);
             $address->plus4 = $matches[7];
         }
         $this->_checkAddress($address);
@@ -44,37 +43,41 @@ class USParser extends BaseCountryParser implements iParser
     }
 
     /**
-     * 检查地址真实性
-     * Check address authenticity
+     * 检查地址真实性 (Check address authenticity)
      * CarpCai <2018/12/2 7:52 PM>
+     *
+     * @param AddressStruct $address
+     * @return void
      */
-    private function _checkAddress(&$address)
+    private function _checkAddress($address)
     {
         //check state
-        $statesMap = json_decode(file_get_contents(__DIR__ . '/../Json/US_states.json'), true);
+        $statesMap = UsaData::ALL_STATES;
         $state = $address->state;
-        if(in_array($state, array_keys($statesMap))){
+        if (isset($statesMap[$state])) {
+            // Check if we have a valid 2-char state code
             $address->state_text = $statesMap[$state];
-        }else if (in_array($state, array_values($statesMap))){
-            $address->state = array_flip($statesMap)[$state];
+        } elseif ($stateKey = array_search($state, $statesMap, true)) {
+            // Try checking for the full state text
+            $address->state = $stateKey;
             $address->state_text = $state;
-        }else{
+        } else {
             $this->_setError($address, 'The state does not exist');
         }
 
         //check addressLine1
         list($HouseNumber) = explode(' ', $address->addressLine1);
-        if(!is_numeric($HouseNumber)){
+        if (!is_numeric($HouseNumber)) {
             $this->_setError($address, 'The address must start with a number');
         }
 
         //check zipcode
-        if(!is_numeric($address->zipcode)){
+        if (!is_numeric($address->zipcode)) {
             $this->_setError($address, 'the Zip code must be a number');
         }
 
         //check plus4
-        if (isset($address->plus4) && !is_numeric($address->plus4)) {
+        if (!empty($address->plus4) && !is_numeric($address->plus4)) {
             $this->_setError($address, 'the plus4 code must be a number');
         }
     }

--- a/src/Countries/USParser.php
+++ b/src/Countries/USParser.php
@@ -35,7 +35,7 @@ class USParser extends BaseCountryParser implements iParser
         if (!$matches || count($matches) < 6) {
             $address = new AddressStruct([]);
             $address->error_code = -1;
-            $address->error_message = 'Failed to match regular expression.';
+            $address->error_message = 'Failed to match regular expression';
             return $address;
         }
 

--- a/src/Countries/iParser.php
+++ b/src/Countries/iParser.php
@@ -8,9 +8,15 @@
 
 namespace CarpCai\AddressParser\Countries;
 
+use CarpCai\AddressParser\AddressStruct;
 
 interface iParser
 {
-
+    /**
+     * @param string $address Input address string to be parsed
+     *
+     * @return AddressStruct Returns an AddressStruct; if a parse error occurred, the AddressStruct will have an
+     *                       error_code and error_message set on it.
+     */
     public function split($address);
 }

--- a/src/Data/UsaData.php
+++ b/src/Data/UsaData.php
@@ -7,6 +7,8 @@ namespace CarpCai\AddressParser\Data;
  */
 class UsaData
 {
+    const COUNTRY_CODE = 'US';
+
     /** @var string[] Map of 2 letter state code to the full state name */
     const ALL_STATES = [
         'AL' => 'Alabama',

--- a/src/Data/UsaData.php
+++ b/src/Data/UsaData.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace CarpCai\AddressParser\Data;
+
+/**
+ * Various hard coded data for the USA (United States of America)
+ */
+class UsaData
+{
+    /** @var string[] Map of 2 letter state code to the full state name */
+    const ALL_STATES = [
+        'AL' => 'Alabama',
+        'AK' => 'Alaska',
+        'AZ' => 'Arizona',
+        'AR' => 'Arkansas',
+        'CA' => 'California',
+        'CO' => 'Colorado',
+        'CT' => 'Connecticut',
+        'DE' => 'Delaware',
+        'FL' => 'Florida',
+        'GA' => 'Georgia',
+        'HI' => 'Hawaii',
+        'ID' => 'Idaho',
+        'IL' => 'Illinois',
+        'IN' => 'Indiana',
+        'IA' => 'Iowa',
+        'KS' => 'Kansas',
+        'KY' => 'Kentucky',
+        'LA' => 'Louisiana',
+        'ME' => 'Maine',
+        'MD' => 'Maryland',
+        'MA' => 'Massachusetts',
+        'MI' => 'Michigan',
+        'MN' => 'Minnesota',
+        'MS' => 'Mississippi',
+        'MO' => 'Missouri',
+        'MT' => 'Montana',
+        'NE' => 'Nebraska',
+        'NV' => 'Nevada',
+        'NH' => 'New Hampshire',
+        'NJ' => 'New Jersey',
+        'NM' => 'New Mexico',
+        'NY' => 'New York',
+        'NC' => 'North Carolina',
+        'ND' => 'North Dakota',
+        'OH' => 'Ohio',
+        'OK' => 'Oklahoma',
+        'OR' => 'Oregon',
+        'PA' => 'Pennsylvania',
+        'RI' => 'Rhode Island',
+        'SC' => 'South Carolina',
+        'SD' => 'South Dakota',
+        'TN' => 'Tennessee',
+        'TX' => 'Texas',
+        'UT' => 'Utah',
+        'VT' => 'Vermont',
+        'VA' => 'Virginia',
+        'WA' => 'Washington',
+        'WV' => 'West Virginia',
+        'WI' => 'Wisconsin',
+        'WY' => 'Wyoming',
+    ];
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -16,52 +16,51 @@ class Parser
 
     /**
      * CarpCai <2018/12/1 10:46 PM>
-     * @param $addressString
-     * @param string $country
-     * @return AddressStruct
+     * @param string $country Country to load assumptions for. Currently, only US is supported.
      */
     public function __construct($country = AddressStruct::US)
     {
         $this->setCountry($country);
     }
 
+    /**
+     * @param string $country Two letter country code.
+     *
+     * @return $this
+     */
     public function setCountry($country)
     {
-        if (in_array($country, [AddressStruct::US])) {
+        if (in_array($country, [AddressStruct::US], true)) {
             $this->country = AddressStruct::US;
-            return $this;
         }
         return $this;
     }
 
     /**
-     *
      * CarpCai <2018/12/1 10:20 PM>
+     *
+     * @param string $addressString
+     * @param string $country Two letter country code.
+     *
+     * @return AddressStruct
      */
-    static function newParse($addressString, $country = AddressStruct::US)
+    public static function newParse($addressString, $country = AddressStruct::US)
     {
         $class = new static($addressString);
         $class->setCountry($country);
-        return $class->_parse($addressString);
+        return $class->parse($addressString);
     }
 
     /**
      * CarpCai <2018/12/1 10:19 PM>
+     *
+     * @param string $addressString
+     *
+     * @return AddressStruct
      */
     public function parse($addressString)
     {
-        return $this->_parse($addressString);
-    }
-
-    /**
-     * CarpCai <2018/12/1 10:46 PM>
-     * @param $addressString
-     * @param string $country
-     * @return AddressStruct
-     */
-    private function _parse($addressString, $country = AddressStruct::US)
-    {
-        //TODO: 根据不同国家生成不同实例
+        //TODO: 根据不同国家生成不同实例 (Generate different examples according to different countries)
         return (new USParser())->split($addressString);
     }
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -9,6 +9,7 @@
 namespace CarpCai\AddressParser;
 
 use CarpCai\AddressParser\Countries\USParser;
+use CarpCai\AddressParser\Data\UsaData;
 
 class Parser
 {
@@ -18,7 +19,7 @@ class Parser
      * CarpCai <2018/12/1 10:46 PM>
      * @param string $country Country to load assumptions for. Currently, only US is supported.
      */
-    public function __construct($country = AddressStruct::US)
+    public function __construct($country = UsaData::COUNTRY_CODE)
     {
         $this->setCountry($country);
     }
@@ -30,8 +31,8 @@ class Parser
      */
     public function setCountry($country)
     {
-        if (in_array($country, [AddressStruct::US], true)) {
-            $this->country = AddressStruct::US;
+        if (in_array($country, [UsaData::COUNTRY_CODE], true)) {
+            $this->country = $country;
         }
         return $this;
     }
@@ -44,7 +45,7 @@ class Parser
      *
      * @return AddressStruct
      */
-    public static function newParse($addressString, $country = AddressStruct::US)
+    public static function newParse($addressString, $country = UsaData::COUNTRY_CODE)
     {
         $class = new static($addressString);
         $class->setCountry($country);

--- a/tests/AddressParserTest.php
+++ b/tests/AddressParserTest.php
@@ -59,10 +59,23 @@ class AddressParserTest extends TestCase
 
     }
 
-    public function testWrongUSAddressParse()
+    public function providerForParseErrors()
     {
-        $address = Parser::newParse('Test Drive, Testville, CA 98773');
+        return [
+            ['Test Drive, Testville, CA 98773', -1, 'The address must start with a number'],
+            ['I don\'t match anything', -1, 'Failed to match regular expression'],
+            ['555 Test Drive, Testville, YX 98773-1111', -1, 'The state does not exist'],
+        ];
+    }
 
-        $this->assertSame( -1,  $address->error_code);
+    /**
+     * @dataProvider providerForParseErrors
+     */
+    public function testWrongUSAddressParse($inputString, $errorCode, $errorMessage)
+    {
+        $address = Parser::newParse($inputString);
+
+        $this->assertSame($errorCode,  $address->error_code);
+        $this->assertSame($errorMessage,  $address->error_message);
     }
 }

--- a/tests/AddressParserTest.php
+++ b/tests/AddressParserTest.php
@@ -9,18 +9,15 @@ namespace CarpCai\AddressParser\Tests;
 use CarpCai\AddressParser\Parser;
 use PHPUnit\Framework\TestCase;
 
-
 class AddressParserTest extends TestCase
 {
-//    public function setUp(){}
-//    public function tearDown(){}
-    /**
-     * 测试是否能解析美国的地址
-     * CarpCai <2018/12/1 12:40 PM>
-     */
-    public function testRightUSAddressParse()
+    public function providerForUsAddressesAndExpectations()
     {
-        $addressesArray = [
+        return [
+            [
+                "Lee Harvey\n1582 Mountain Rd.\nTest River, NY 44349",
+                ['1582 Mountain Rd.', 'Test River', 'NY', '44349', 'Lee Harvey', '', ''],
+            ],
             ['555 Test Drive, Testville, CA 98773-1111', ['555 Test Drive', 'Testville', 'CA', '98773', '', '1111']],
             ['555 Test Drive, Testville, CA 98773', ['555 Test Drive', 'Testville', 'CA', '98773', '', '']],
             ['555 Test Drive, Testville, California 98773', ['555 Test Drive', 'Testville', 'CA', '98773', '', '']],
@@ -30,24 +27,42 @@ class AddressParserTest extends TestCase
             ['555 Test Drive,Testville,CA', ['555 Test Drive', 'Testville', 'CA', '', '', '']],
             ['Carp Cai 555 Test Drive,Testville,CA', ['555 Test Drive', 'Testville', 'CA', '', 'Carp Cai', '', '']],
         ];
-
-        foreach ($addressesArray as $addresses) {
-            $addressRes = Parser::newParse($addresses[0]);
-
-            $this->assertEquals( $addresses[1][0],  $addressRes->addressLine1);
-            $this->assertEquals( $addresses[1][1],  $addressRes->city);
-            $this->assertEquals( $addresses[1][2],  $addressRes->state);
-            $this->assertEquals( $addresses[1][3],  $addressRes->zipcode);
-            $this->assertEquals( $addresses[1][4],  $addressRes->name);
-            $this->assertEquals( $addresses[1][5],  $addressRes->plus4);
-        }
     }
 
+    /**
+     * 测试是否能解析美国的地址
+     * CarpCai <2018/12/1 12:40 PM>
+     * @dataProvider providerForUsAddressesAndExpectations
+     *
+     * @param string $inputString Input test string (comes via dataProvider)
+     * @param array $expectedObjValues Expected parsed values (comes via dataProvider)
+     */
+    public function testRightUSAddressParse($inputString, array $expectedObjValues)
+    {
+        $expectedObjValues = [
+            'addressLine1' => $expectedObjValues[0],
+            'city' => $expectedObjValues[1],
+            'state' => $expectedObjValues[2],
+            'zipcode' => $expectedObjValues[3],
+            'name' => $expectedObjValues[4],
+            'plus4' => $expectedObjValues[5],
+        ];
+
+        $addressRes = Parser::newParse($inputString);
+
+        $this->assertSame($expectedObjValues['addressLine1'], $addressRes->addressLine1);
+        $this->assertSame($expectedObjValues['city'],  $addressRes->city);
+        $this->assertSame($expectedObjValues['state'],  $addressRes->state);
+        $this->assertSame($expectedObjValues['zipcode'],  $addressRes->zipcode);
+        $this->assertSame($expectedObjValues['name'],  $addressRes->name);
+        $this->assertSame($expectedObjValues['plus4'],  $addressRes->plus4);
+
+    }
 
     public function testWrongUSAddressParse()
     {
         $address = Parser::newParse('Test Drive, Testville, CA 98773');
 
-        $this->assertEquals( -1,  $address->error_code);
+        $this->assertSame( -1,  $address->error_code);
     }
 }

--- a/tests/AddressStructTest.php
+++ b/tests/AddressStructTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace CarpCai\AddressParser\Tests;
+
+use CarpCai\AddressParser\AddressStruct;
+use PHPUnit\Framework\TestCase;
+
+class AddressStructTest extends TestCase
+{
+    public function testConstructorWithBadData()
+    {
+        $struct = new AddressStruct([]);
+        $this->assertNull($struct->addressLine1);
+    }
+}


### PR DESCRIPTION
The main functionality enhancement of this PR is to add support for addresses that are delimited by line breaks, such as this:

```
Lee Harvey
1582 Mountain Rd.
Test River, NY 44349
```

The simple solution here is to replace any line breaks with a `, ` prior to calling the RegEx, so the core regex is left unchanged.

Some additional changes were made:

- `UsaData.php` class added, which stores the US state list instead of using the JSON file. PHP files are opcached and thus the performance is super fast and in-memory most of the time, meanwhile JSON files must be reparsed each time (and in fact the method call was re-parsing it each time, so even if it stayed as JSON it could be at least cached to a variable, but making it a PHP file will get the most benefits).
- AddressStruct::US constant now points to UsaData::COUNTRY_CODE, as it makes sense to put any data relevant to the country in that class now. It was left there still for backwards compatibility (for PHP 5.6 support, constants do not have visibility keyword so they are always PUBLIC by default)
- Removed `&` (ampersand) to method arguments which accept an object. All objects in PHP are passed by reference, the `&` is redundant and doesn't do anything different. 
- Some minor code formatting tweaks (staying close to PSR-2 standard, though I didn't change the whole project)
- Handled a few error cases in both code and unit test
- Unit test coverage is now `98.33%`