### PR TITLE
fix plus4 check

### DIFF
--- a/src/Countries/USParser.php
+++ b/src/Countries/USParser.php
@@ -74,7 +74,7 @@ class USParser extends BaseCountryParser implements iParser
         }
 
         //check plus4
-        if (isset($address->plus4) && !is_numeric($address->plus4)) {
+        if (isset($address->plus4) && $address->plus4 && !is_numeric($address->plus4)) {
             $this->_setError($address, 'the plus4 code must be a number');
         }
     }


### PR DESCRIPTION
plus4 gets set to a empty string or similar falsy value, causing unexpected failures