### PR TITLE
handle lowercase state names

### DIFF
--- a/src/Countries/USParser.php
+++ b/src/Countries/USParser.php
@@ -29,7 +29,7 @@ class USParser extends BaseCountryParser implements iParser
         $address = new AddressStruct([
             'name'         => trim($name),
             'city'         => trim($city),
-            'state'        => trim($state),
+            'state'        => strtoupper(trim($state)),
             'addressLine1' => trim($street),
             'zipcode'      => trim($zipcode),
         ]);


### PR DESCRIPTION
if the user enters a lowercase or mixed-case state name, convert it to uppercase to avoid an `The state does not exist` error.